### PR TITLE
[modify]起動時の遠征報告書読み込みエラーを修正 logbookフォーマット対応

### DIFF
--- a/src/main/java/logbook/internal/MissionLogs.java
+++ b/src/main/java/logbook/internal/MissionLogs.java
@@ -58,7 +58,7 @@ public class MissionLogs {
                     .collect(Collectors.toList());
         }
     }
-    
+
 
     /**
      * 遠征統計のベース
@@ -103,7 +103,12 @@ public class MissionLogs {
          */
         public SimpleMissionLog(String line) {
             String[] columns = line.split(",", -1);
-            
+
+            boolean isNewFormat = true;
+            if (columns.length == 7) {
+                isNewFormat = false;
+            }
+
             this.setDateString(columns[0]);
             // 任務の更新時間が午前5時のため
             // 日付文字列を日本時間として解釈した後、GMT+04:00のタイムゾーンに変更します
@@ -112,12 +117,21 @@ public class MissionLogs {
                     .withZoneSameInstant(ZoneId.of("GMT+04:00"));
             this.setDate(date);
             this.setResult(columns[1]);
-            this.setArea(columns[2]);
-            this.setName(columns[3]);
-            this.setFuel(Integer.parseInt(columns[4]));
-            this.setAmmo(Integer.parseInt(columns[5]));
-            this.setMetal(Integer.parseInt(columns[6]));
-            this.setBauxite(Integer.parseInt(columns[7]));
+            if (isNewFormat) {
+                this.setArea(columns[2]);
+                this.setName(columns[3]);
+                this.setFuel(Integer.parseInt(columns[4]));
+                this.setAmmo(Integer.parseInt(columns[5]));
+                this.setMetal(Integer.parseInt(columns[6]));
+                this.setBauxite(Integer.parseInt(columns[7]));
+            } else {
+                this.setArea("");
+                this.setName(columns[2]);
+                this.setFuel(columns[3].equals("") ? 0 : Integer.parseInt(columns[3]));
+                this.setAmmo(columns[4].equals("") ? 0 : Integer.parseInt(columns[4]));
+                this.setMetal(columns[5].equals("") ? 0 : Integer.parseInt(columns[5]));
+                this.setBauxite(columns[6].equals("") ? 0 : Integer.parseInt(columns[6]));
+            }
             if (columns.length > 8)
                 this.setItem1name(columns[8]);
             if (columns.length > 9)

--- a/src/test/java/logbook/internal/MissionLogsTest.java
+++ b/src/test/java/logbook/internal/MissionLogsTest.java
@@ -1,0 +1,36 @@
+package logbook.internal;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import logbook.internal.MissionLogs.SimpleMissionLog;
+
+class MissionLogsTest {
+
+    @Test
+    void test_old_format() {
+        String old_logbook_mission_failed_str = "2014-08-01 05:00:00,失敗,東京急行,,,,";
+        SimpleMissionLog simpleMissionLog_oldformat_fail = new SimpleMissionLog(old_logbook_mission_failed_str);
+
+        Assert.assertEquals("", simpleMissionLog_oldformat_fail.getArea());
+        Assert.assertEquals("東京急行", simpleMissionLog_oldformat_fail.getName());
+
+        Assert.assertEquals(0, simpleMissionLog_oldformat_fail.getFuel());
+        Assert.assertEquals(0, simpleMissionLog_oldformat_fail.getAmmo());
+        Assert.assertEquals(0, simpleMissionLog_oldformat_fail.getMetal());
+        Assert.assertEquals(0, simpleMissionLog_oldformat_fail.getBauxite());
+
+        String old_logbook_mission_success_str = "2014-08-01 05:00:00,成功,東京急行,0,380,270,0";
+        SimpleMissionLog simpleMissionLog_oldformat_success = new SimpleMissionLog(old_logbook_mission_success_str);
+
+        Assert.assertEquals("", simpleMissionLog_oldformat_fail.getArea());
+        Assert.assertEquals("東京急行", simpleMissionLog_oldformat_fail.getName());
+
+        Assert.assertEquals(0, simpleMissionLog_oldformat_success.getFuel());
+        Assert.assertEquals(380, simpleMissionLog_oldformat_success.getAmmo());
+        Assert.assertEquals(270, simpleMissionLog_oldformat_success.getMetal());
+        Assert.assertEquals(0, simpleMissionLog_oldformat_success.getBauxite());
+
+    }
+
+}


### PR DESCRIPTION
#### 問題解析
logbook時から利用している場合、旧旧遠征報告書情報読み込み時にエラーが発生する

#### 変更内容
旧フォーマット読み込み時の処理を追加

