### PR TITLE
戦闘ログ フィルタの挙動を調整

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>logbook-kai</name>
     <artifactId>logbook-kai</artifactId>
     <groupId>logbook</groupId>
-    <version>24.0.30</version>
+    <version>24.0.31</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>


### PR DESCRIPTION
- 戦闘ログ フィルタの挙動を調整

1. 海域名に1-1などを追加
2. 評価、艦隊行動、陣形、制空権の並び順を調整
3. ドロップ艦種選択時にドロップ艦娘のアイテムが連動する様に変更